### PR TITLE
fix(tofs): use `tpldir` derivative `topdir` for pillar (config) paths

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -33,6 +33,9 @@ stack:
     #   default: default_alt
     # files:
     #   stack-config:
-    #     - 'example_alt.tmpl'
-    #     - 'example_alt.tmpl.jinja'
-
+    #     - 'sdb.conf'
+    #     - 'sdb_alt.conf'
+    #   stack-keys-config:
+    #     - 'sdb_keys.conf'
+    #     - 'sdb_keys_alt.conf'
+          

--- a/stack/config.sls
+++ b/stack/config.sls
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # vim: ft=sls
 
+{#- Get the `topdir` from `tpldir` #}
+{%- set topdir = tpldir.split('/')[0] %}
 {%- from "stack/map.jinja" import stack with context %}
 {%- from "stack/macros.jinja" import files_switch with context %}
 {% set map = salt['slsutil.renderer']("salt://stack/map.sls") %}
@@ -10,7 +12,7 @@ stack-config:
     - name: {{ stack.sdb.config }}
     - source: {{ files_switch(
                     salt['config.get'](
-                        tpldir ~ ':tofs:files:stack-config',
+                        topdir ~ ':tofs:files:stack-config',
                         ['sdb.conf']
                     )
               ) }}
@@ -36,7 +38,7 @@ stack-keys-config:
     - name: {{ stack.sdb.sdb_keys }}
     - source: {{ files_switch(
                     salt['config.get'](
-                        tpldir ~ ':tofs:files:stack-config',
+                        topdir ~ ':tofs:files:stack-keys-config',
                         ['sdb_keys.conf']
                     )
               ) }}

--- a/stack/macros.jinja
+++ b/stack/macros.jinja
@@ -42,30 +42,42 @@
             - salt://xxx/files/default/etc/yyy/zzz.conf.jinja
           - stack: jinja
   #}
-  {%- set path_prefix = salt['config.get'](tpldir ~ ':tofs:path_prefix', tpldir) %}
-  {%- set files_dir = salt['config.get'](tpldir ~ ':tofs:dirs:files', 'files') %}
+  {#- Get the `topdir` from `tpldir` #}
+  {%- set topdir = tpldir.split('/')[0] %}
+  {%- set path_prefix = salt['config.get'](topdir ~ ':tofs:path_prefix', topdir) %}
+  {%- set files_dir = salt['config.get'](topdir ~ ':tofs:dirs:files', 'files') %}
   {%- set files_switch_list = salt['config.get'](
-      tpldir ~ ':tofs:files_switch',
+      topdir ~ ':tofs:files_switch',
       default_files_switch
   ) %}
-  {#- Append an empty value to evaluate as `default` in the loop below #}
-  {%- if '' not in files_switch_list %}
-    {%- do files_switch_list.append('') %}
-  {%- endif %}
-  {%- for fs in files_switch_list %}
-    {%- for file in files %}
-      {%- if fs %}
-        {%- set fs_dir = salt['config.get'](fs, fs) %}
-      {%- else %}
-        {%- set fs_dir = salt['config.get'](tpldir ~ ':tofs:dirs:default', 'default') %}
-      {%- endif %}
-      {%- set url = '- salt://' ~ '/'.join([
-          path_prefix,
-          files_dir,
-          fs_dir,
-          file.lstrip('/')
-      ]) %}
+  {#- Only add to [''] when supporting older TOFS implementations #}
+  {%- for path_prefix_ext in [''] %}
+    {%- set path_prefix_inc_ext = path_prefix ~ path_prefix_ext %}
+    {#- For older TOFS implementation, use `files_switch` from the pillar #}
+    {#- Use the default, new method otherwise #}
+    {%- set fsl = salt['pillar.get'](
+        topdir ~ path_prefix_ext|replace('/', ':') ~ ':files_switch',
+        files_switch_list
+    ) %}
+    {#- Append an empty value to evaluate as `default` in the loop below #}
+    {%- if '' not in fsl %}
+      {%- do fsl.append('') %}
+    {%- endif %}
+    {%- for fs in fsl %}
+      {%- for file in files %}
+        {%- if fs %}
+          {%- set fs_dir = salt['config.get'](fs, fs) %}
+        {%- else %}
+          {%- set fs_dir = salt['config.get'](topdir ~ ':tofs:dirs:default', 'default') %}
+        {%- endif %}
+        {%- set url = '- salt://' ~ '/'.join([
+            path_prefix_inc_ext,
+            files_dir,
+            fs_dir,
+            file.lstrip('/')
+        ]) %}
 {{ url | indent(indent_width, true) }}
+      {%- endfor %}
     {%- endfor %}
   {%- endfor %}
 {%- endmacro %}


### PR DESCRIPTION
* With nested `.sls` files, `tpldir` respectively resolves to:
  - `stack/<subdir>`
* Without this fix, only the default value provided is ever used, respectively:
  - `stack-config`:      ['sdb.conf']
  - `stack-keys-config`: ['sdb_keys.conf']
* Follows-on from:
  - https://github.com/saltstack-formulas/systemd-formula/pull/22
  - https://github.com/saltstack-formulas/template-formula/pull/49